### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+FNMessageBots is a Python 3.9+ Flask application that monitors FN NAS (飞牛 NAS) event logs (SQLite databases) and pushes notifications to multiple platforms (WeChat Work, DingTalk, Feishu, Bark, PushPlus, Magic Push, SMTP).
+
+### Running the application
+
+```bash
+PYTHONPATH=. LOGGER_DB_PATH=./test_db/logger_data.db3 python3 src/main.py
+```
+
+The Web UI starts on port **18080** by default (configurable via `UI_PORT` env var). Without any webhook configured, the app still starts and provides the Web configuration UI.
+
+### Key caveats
+
+- **No formal test suite exists** in this codebase. There are no `tests/` directory or test files. Validation is done via type checking with `basedpyright` and manual testing of the running application.
+- **Type checking**: Run `basedpyright src/` from the project root. The tool reports pre-existing warnings/errors in the codebase (not blocking).
+- **PYTHONPATH must include the repo root** (not `src/`) so that `from config import Config` and similar imports resolve correctly. Setting `PYTHONPATH=.` at the repo root works.
+- **SQLite database**: The app requires a SQLite database at `logger_db_path` (or set via `LOGGER_DB_PATH` env var). For development, create a dummy one with a `log` table (columns: `id`, `serviceId`, `uid`, `uname`, `logtime`, `loglevel`, `eventId`, `parameter`, `category`). Without a valid DB, the app still starts but skips polling.
+- **Config file location**: The app looks for `config/config.json` relative to the project root (or `/app/config/config.json` in Docker). The file already exists in the repo.
+- **Hot reload**: Saving config via the Web UI triggers hot reload—no restart needed.
+- **No linter (ruff/flake8) is configured** in this project. Only `basedpyright` is used for static analysis.
+- **Dependencies install to user site** (`--user`) on this VM since system site-packages is not writable. All packages land in `~/.local/lib/python3.12/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

## Changes
- Created `AGENTS.md` with key development caveats (PYTHONPATH, SQLite test DB setup, type checking with basedpyright, config file location, etc.)

## Development Environment Verification

The following was verified during setup:
- Python dependencies install correctly via `pip install -r requirements.txt`
- Application starts and serves Web UI on port 18080
- Config save/load with hot reload works end-to-end
- Type checking runs with `basedpyright src/`

[FnMessageBot config page running](https://cursor.com/agents/bc-8cfe8aca-9146-4b86-ad6e-a1aaa03fafb4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffnmessagebot_config_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cfe8aca-9146-4b86-ad6e-a1aaa03fafb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cfe8aca-9146-4b86-ad6e-a1aaa03fafb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

